### PR TITLE
Add xAppVersion and xAssosciatedBrand config variables

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@DugganB:registry=https://npm.pkg.github.com

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Time to update the Homebridge config to replace the placeholders from step 2.
 "xApiKey" is the API Key you got in Step 5. Yes keep the x in front of the key name.
 "manufacturer", "model" and "serialNumber" can be anything.
 
+If you are on the new American Standard Home service, make sure you set "X-AppVersion" to the latest app version (`5.16.0` at the time of writing) and set "X-AssociatedBrand" to `asair` in your config.
+
 ## 7. Cleanup
 You can remove the nexia-api npm module and nexia.js once you have the Mobile ID and API keys.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-nexia-thermostat-ts",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Homebridge Nexia plugin in Typescript",
   "main": "dist/accessory.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "@dugganb/homebridge-nexia-thermostat-ts",
+  "name": "homebridge-nexia-american-standard-thermostat-ts",
   "version": "0.3.8",
-  "description": "Homebridge Nexia plugin in Typescript",
+  "description": "Homebridge Nexia and American Standard plugin in Typescript",
   "main": "dist/accessory.js",
   "scripts": {
     "clean": "rimraf ./dist",
     "postpublish": "npm run clean",
     "test": "mocha",
-    "lint": "eslint src/**.ts --max-warnings=0",
+    "lint": "eslint src/**.ts",
     "watch": "npm run build && npm link && nodemon",
     "build": "rimraf ./dist && tsc",
     "prepublishOnly": "npm run lint && npm run build"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "homebridge-nexia-thermostat-ts",
+  "name": "@dugganb/homebridge-nexia-thermostat-ts",
   "version": "0.3.8",
   "description": "Homebridge Nexia plugin in Typescript",
   "main": "dist/accessory.js",
@@ -17,7 +17,7 @@
     "ts-node": "^9.1.1",
     "typescript": "^3.8.3"
   },
-  "author": "@cuperteeno <inalip.luhar@gmail.com>",
+  "author": "@dugganb <dugganbmail@gmail.com>",
   "engines": {
     "homebridge": ">=1.0.0"
   },
@@ -31,10 +31,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/rahulpilani/homebridge-nexia-thermostat-ts.git"
+    "url": "git://github.com/DugganB/homebridge-nexia-thermostat-ts.git"
   },
   "bugs": {
-    "url": "https://github.com/rahulpilani/homebridge-nexia-thermostat-ts/issues"
+    "url": "https://github.com/DugganB/homebridge-nexia-thermostat-ts/issues"
   },
   "devDependencies": {
     "@types/node": "10.17.19",
@@ -45,5 +45,5 @@
     "mocha": "^8.3.0",
     "rimraf": "^3.0.2"
   },
-  "homepage": "https://github.com/rahulpilani/homebridge-nexia-thermostat-ts/blob/master/README.md"
+  "homepage": "https://github.com/DugganB/homebridge-nexia-thermostat-ts#readme"
 }

--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -341,7 +341,7 @@ class NexiaThermostat {
   handleTargetTemperatureSet(value: any, callback: (arg0: null) => void) {
     this.log.debug('Triggered SET TargetTemperature:' + value);
     this.computeState((state: { heatingSetpoint: any; coolingSetpoint: any; mappedMode: any; setPointUrl: string, scale: number }) => {
-      let payload = { 
+      const payload = { 
         heat: this.convertTemperature(this.currentTemperatureScale, state.scale, state.heatingSetpoint), 
         cool: this.convertTemperature(this.currentTemperatureScale, state.scale, state.coolingSetpoint) 
       }

--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -114,7 +114,7 @@ class NexiaThermostat {
     this.scaleMap.set("c", this.Characteristic.TemperatureDisplayUnits.CELSIUS);
     this.currentTemperatureScale = this.Characteristic.TemperatureDisplayUnits.CELSIUS; //default to C
 
-    let headers: {
+    const headers: {
       "X-MobileId": string, 
       "X-ApiKey": string, 
       "Content-Type": string, 

--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -56,6 +56,8 @@ class NexiaThermostat {
   private readonly thermostatIndex: number;
   private readonly xMobileId: string;
   private readonly xApiKey: string;
+  private readonly xAppVersion: string;
+  private readonly xAssociatedBrand: string;
   private readonly manufacturer: string;
   private readonly model: string;
   private readonly config: any;
@@ -84,6 +86,9 @@ class NexiaThermostat {
     this.thermostatIndex = config.thermostatIndex;
     this.xMobileId = config.xMobileId;
     this.xApiKey = config.xApiKey;
+    this.xAppVersion = config.xAppVersion || "";
+    this.xAssociatedBrand = config.xAssociatedBrand || "";
+    
     this.manufacturer = config.manufacturer;
     this.model = config.model;
     this.serialNumber = config.serialNumber;
@@ -109,11 +114,19 @@ class NexiaThermostat {
     this.scaleMap.set("c", this.Characteristic.TemperatureDisplayUnits.CELSIUS);
     this.currentTemperatureScale = this.Characteristic.TemperatureDisplayUnits.CELSIUS; //default to C
 
-    const headers = {
+    let headers: {
+      "X-MobileId": string, 
+      "X-ApiKey": string, 
+      "Content-Type": string, 
+      "X-AppVersion"?: string, 
+      "X-AssociatedBrand"?: string
+    } = {
       "X-MobileId": this.xMobileId,
       "X-ApiKey": this.xApiKey,
       "Content-Type": "application/json"
     }
+    if(this.xAppVersion) headers["X-AppVersion"] = this.xAppVersion;
+    if(this.xAssociatedBrand) headers["X-AssociatedBrand"] = this.xAssociatedBrand
 
     this.gotapiGet = got.extend({
       prefixUrl: this.apiroute,


### PR DESCRIPTION
The American Standard Home service which is now live requires a couple of extra headers. It requires the `X-AppVersion` and `X-AssociatedBrand` header.  

If a request is sent without those two headers, from a fully setup `mobileId` <-> `apikey `pair, American Standard will respond with an error:
```
{
    "success": false,
    "error": {
        "code": 5,
        "message": "This mobile device is not valid. We see you are trying to log in to Nexia™. We’ve updated your experience, and you’ll need to download American Standard® Home to log in. Need help? Call our customer support team at: 877-374-0697",
        "additional_error_fields": {}
    },
    "result": null
}
```

After the above response the mobile device is removed from the account and API access is disabled.